### PR TITLE
Use variables in requests.

### DIFF
--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -25,7 +25,7 @@ Feature:
 	Scenario: Setting body payload from file
 		Given I pipe contents of file ./test/features/fixtures/requestbody.xml to body
 		When I POST to /post
-		Then response body should contain "data": "<a>b</a>"
+		Then response body should contain "<a>b</a>"
 
 	Scenario: Sending request with basic auth authentication
 		Given I have basic authentication credentials username and password

--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -46,7 +46,7 @@ Feature:
 
 	Scenario: Checking headers in response
 		When I GET /xml
-		Then response header server should exist 
+		Then response header server should exist
 		And response header boo should not exist
 
 	Scenario: Response code checks
@@ -119,3 +119,32 @@ Feature:
 
 	Scenario: checking values of scenario variables
 		Then value of scenario variable title should be undefined
+
+	Scenario: using unknown variable in request path
+		When I GET /get?fizz=`UNKNOWN_VARIABLE`
+		Then I store the value of body path $.args.fizz as value2 in global scope
+		Then value of global variable value2 should be `UNKNOWN_VARIABLE`
+
+	Scenario: using global variable in request path
+		When I GET /get?foo=bar
+		Then I store the value of body path $.args.foo as value1 in global scope
+		When I GET /get?fizz=`value1`
+		Then I store the value of body path $.args.fizz as value2 in global scope
+		Then value of global variable value2 should be bar
+
+	Scenario: using scenario variable in request path
+		When I GET /get?foo=bar
+		Then I store the value of body path $.args.foo as value3 in scenario scope
+		When I GET /get?fizz=`value3`
+		Then I store the value of body path $.args.fizz as value4 in scenario scope
+		Then value of scenario variable value4 should be bar
+
+	Scenario: using scenario variable and global variables in request path
+		When I GET /get?arg1=foo&arg2=bar
+		Then I store the value of body path $.args.arg1 as value5 in scenario scope
+		Then I store the value of body path $.args.arg2 as value6 in global scope
+		When I GET /get?arg1=`value5`&arg2=`value6`
+		Then I store the value of body path $.args.arg1 as value7 in scenario scope
+		Then I store the value of body path $.args.arg2 as value8 in global scope
+		Then value of scenario variable value7 should be foo
+		Then value of global variable value8 should be bar

--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -148,3 +148,18 @@ Feature:
 		Then I store the value of body path $.args.arg2 as value8 in global scope
 		Then value of scenario variable value7 should be foo
 		Then value of global variable value8 should be bar
+
+	Scenario: comparing response body to JSON
+		Given I set body to { "firstnames": ["John", "Robert"], "lastname": "Doe", "foo": { "bar": true, "age": 30 }}
+		When I POST to /post
+		Then the JSON should be
+		"""
+		{
+			"lastname": "Doe",
+			"firstnames": ["John", "Robert"],
+			"foo": {
+					"bar": true,
+					"age": 30
+				}
+	  }
+		"""

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -200,7 +200,15 @@ module.exports = function() {
 		if (this.apickli.assertScenarioVariableValue(variableName, variableValue)) {
 			callback();
 		} else {
-			callback.fail('value of variable ' + variableName + ' isn\'t equal to ' + variableValue);
+			callback.fail('value of scenario variable ' + variableName + ' isn\'t equal to ' + variableValue);
+		}
+	});
+
+	this.Then(/^value of global variable (.*) should be (.*)$/, function(variableName, variableValue, callback) {
+		if (this.apickli.assertGlobalVariableValue(variableName, variableValue)) {
+			callback();
+		} else {
+			callback.fail('value of global variable ' + variableName + ' isn\'t equal to ' + variableValue);
 		}
 	});
 };

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -8,6 +8,16 @@ module.exports = function() {
 		callback();
 	});
 
+	this.Given(/^I set (.*) header to scenario variable (.*)$/, function(headerName, variableName, callback) {
+		this.apickli.addRequestHeaderFromScenarioVariable(headerName, variableName);
+		callback();
+	});
+
+	this.Given(/^I set (.*) header to global variable (.*)$/, function(headerName, variableName, callback) {
+		this.apickli.addRequestHeaderFromGlobalVariable(headerName, variableName);
+		callback();
+	});
+
 	this.Given(/^I set body to (.*)$/, function(bodyValue, callback) {
 		this.apickli.setRequestBody(bodyValue);
 		callback();

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -152,10 +152,12 @@ module.exports = function() {
 	});
 
 	this.Then(/^the JSON should be$/, function(expression, callback) {
-		if (this.apickli.assertResponseBodyIsExpression(expression)) {
+		try {
+			this.apickli.assertResponseBodyIsJSON(expression)
 			callback();
-		} else {
-			callback.fail('the JSON should be ' + expression);
+		}
+		catch(exception) {
+			callback.fail(exception);
 		}
 	});
 

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -92,12 +92,14 @@ module.exports = function() {
 			callback();
 		} else {
 			callback.fail('response header ' + header + ' does not exists in response');
+			console.log('      response header are ' + JSON.stringify(this.apickli.getRealValue()))
 		}
 	});
 
 	this.Then(/^response header (.*) should not exist$/, function(header, callback) {
 		if (this.apickli.assertResponseContainsHeader(header)) {
 			callback.fail('response header ' + header + ' exists in response');
+			console.log('      response headers are ' + JSON.stringify(this.apickli.getRealValue()))
 		} else {
 			callback();
 		}
@@ -108,6 +110,7 @@ module.exports = function() {
 			callback();
 		} else {
 			callback.fail('response body is not valid ' + contentType);
+			console.log('      response body is \n' + this.apickli.getRealValue())
 		}
 	});
 
@@ -116,12 +119,14 @@ module.exports = function() {
 			callback();
 		} else {
 			callback.fail('response code is not ' + responseCode);
+			console.log('      response is \n' + JSON.stringify(this.apickli.getRealValue()))
 		}
 	});
 
 	this.Then(/^response code should not be (\d+)$/, function(responseCode, callback) {
 		if (this.apickli.assertResponseCode(responseCode)) {
-			callback.fail('response code is ' + responseCode);
+			callback.fail('response code should not be ' + responseCode);
+			console.log('      response code is \n' + JSON.stringify(this.apickli.getRealValue()))
 		} else {
 			callback();
 		}
@@ -131,41 +136,48 @@ module.exports = function() {
 		if (this.apickli.assertHeaderValue(header, expression)) {
 			callback();
 		} else {
-			callback.fail('response header ' + header + ' is not ' + expression);
+			callback.fail('response header ' + header +' should be ' + expression);
+			console.log('      response header ' + header + ' is ' + this.apickli.getRealValue())
 		}
 	});
 
 	this.Then(/^response header (.*) should not be (.*)$/, function(header, expression, callback) {
 		if (this.apickli.assertHeaderValue(header, expression)) {
-			callback.fail('response header ' + header + ' is ' + expression);
+			callback.fail('response header ' + header + ' should be ' + expression);
+			console.log('      response header ' + header + ' is ' + this.apickli.getRealValue())
 		} else {
 			callback();
 		}
 	});
 
 	this.Then(/^response body should contain (.*)$/, function(expression, callback) {
-		if (this.apickli.assertResponseBodyContainsExpression(expression)) {
-			callback();
-		} else {
-			callback.fail('response body doesn\'t contain ' + expression);
-		}
-	});
-
-	this.Then(/^the JSON should be$/, function(expression, callback) {
-		try {
-			this.apickli.assertResponseBodyIsJSON(expression)
+		if (this.apickli.assertResponseBodyContainsExpression(expression)){
 			callback();
 		}
-		catch(exception) {
-			callback.fail(exception);
+		else {
+			callback.fail('reponse body should contain ' + expression);
+			console.log('      response body is\n' + this.apickli.getRealValue())
 		}
 	});
 
 	this.Then(/^response body should not contain (.*)$/, function(expression, callback) {
-		if (this.apickli.assertResponseBodyContainsExpression(expression)) {
-			callback.fail('response body contains ' + expression);
-		} else {
+		if(!this.apickli.assertResponseBodyContainsExpression(expression)) {
 			callback();
+		}
+		else {
+			var realValue = this.apickli.getRealValue();
+			callback.fail('reponse body should not contain ' + expression);
+			console.log('      response body is\n' + realValue);
+		}
+	});
+
+	this.Then(/^the JSON should be$/, function(expression, callback) {
+		if(this.apickli.assertResponseBodyIsJSON(expression)) {
+			callback();
+		}
+		else {
+			callback.fail('response body should be \n' + expression);
+		  console.log('      response body is\n' + this.apickli.getRealValue());
 		}
 	});
 
@@ -173,13 +185,15 @@ module.exports = function() {
 		if (this.apickli.assertPathInResponseBodyMatchesExpression(path, value)) {
 			callback();
 		} else {
-			callback.fail('response body path ' + path + ' doesn\'t match ' + value);
+			callback.fail('response body path ' + path + ' should be ' + value);
+		  console.log('      response body is\n' + this.apickli.getRealValue());
 		}
 	});
 
 	this.Then(/^response body path (.*) should not be (.*)$/, function(path, value, callback) {
 		if (this.apickli.assertPathInResponseBodyMatchesExpression(path, value)) {
-			callback.fail('response body path ' + path + ' matches ' + value);
+			callback.fail('response body path ' + path + ' should not be ' + value);
+		  console.log('      response body is\n' + this.apickli.getRealValue());
 		} else {
 			callback();
 		}
@@ -219,7 +233,8 @@ module.exports = function() {
 		if (this.apickli.assertScenarioVariableValue(variableName, variableValue)) {
 			callback();
 		} else {
-			callback.fail('value of scenario variable ' + variableName + ' isn\'t equal to ' + variableValue);
+			callback.fail('value of scenario variable ' + variableName + ' should be ' + variableValue);
+			console.log('      value of scenario variable ' + variableName + ' is ' + this.apickli.getRealValue());
 		}
 	});
 
@@ -227,7 +242,8 @@ module.exports = function() {
 		if (this.apickli.assertGlobalVariableValue(variableName, variableValue)) {
 			callback();
 		} else {
-			callback.fail('value of global variable ' + variableName + ' isn\'t equal to ' + variableValue);
+			callback.fail('value of global variable ' + variableName + ' should be ' + variableValue);
+			console.log('      value of global variable ' + variableName + ' is ' + this.apickli.getRealValue());
 		}
 	});
 };

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -1,6 +1,5 @@
 /* jslint node: true */
 'use strict';
-
 module.exports = function() {
 
 	this.Given(/^I set (.*) header to (.*)$/, function(headerName, headerValue, callback) {
@@ -149,6 +148,14 @@ module.exports = function() {
 			callback();
 		} else {
 			callback.fail('response body doesn\'t contain ' + expression);
+		}
+	});
+
+	this.Then(/^the JSON should be$/, function(expression, callback) {
+		if (this.apickli.assertResponseBodyIsExpression(expression)) {
+			callback();
+		} else {
+			callback.fail('the JSON should be ' + expression);
 		}
 	});
 

--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -24,6 +24,14 @@ Apickli.prototype.addRequestHeader = function(name, value) {
 	this.headers[name] = value;
 };
 
+Apickli.prototype.addRequestHeaderFromScenarioVariable = function(name, variable) {
+	this.headers[name] = this.scenarioVariables(variable);
+};
+
+Apickli.prototype.addRequestHeaderFromGlobalVariable = function(name, variable) {
+	this.headers[name] = globalVariables(variable);
+};
+
 Apickli.prototype.getResponseObject = function() {
 	return this.httpResponse;
 };

--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -175,6 +175,12 @@ Apickli.prototype.assertPathInResponseBodyMatchesExpression = function(path, reg
 	return (regExpObject.test(evalValue));
 };
 
+Apickli.prototype.assertResponseBodyIsExpression = function(expression) {
+	var real = JSON.parse(this.getResponseObject().body).json;
+	var result = areEqual(real, JSON.parse(expression));
+	return result;
+};
+
 Apickli.prototype.assertResponseBodyContainsExpression = function(expression) {
 	var regex = new RegExp(expression);
 	return (regex.test(this.getResponseObject().body));
@@ -313,3 +319,25 @@ var evaluatePath = function(path, content) {
 var base64Encode = function(str) {
 	return new Buffer(str).toString('base64');
 };
+
+/**
+ * Makes a deep comparison of two objects
+ * Returns true when they are equal, false otherwise
+ * This function is intended to compare objects created from JSON string only
+ * So it may not handle properly comparison of other types of objects
+ */
+var areEqual = function(real, expected) {
+	  for ( var property in expected ) {
+	    if ( ! real.hasOwnProperty( property ) ) return false;
+	      // allows to compare expected[ property ] and real[ property ] when set to undefined
+	    if ( expected[ property ] === real[ property ] ) continue;
+	      // if they have the same strict value or identity then they are equal
+
+	    if ( typeof( expected[ property ] ) !== "object" ) return false;
+	      // Numbers, Strings, Functions, Booleans must be strictly equal
+
+	    if ( !areEqual( expected[ property ],  real[ property ] ) ) return false;
+	      // Objects and Arrays must be tested recursively
+	  }
+		return true;
+}

--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -175,10 +175,13 @@ Apickli.prototype.assertPathInResponseBodyMatchesExpression = function(path, reg
 	return (regExpObject.test(evalValue));
 };
 
-Apickli.prototype.assertResponseBodyIsExpression = function(expression) {
+Apickli.prototype.assertResponseBodyIsJSON = function(expression) {
 	var real = JSON.parse(this.getResponseObject().body).json;
 	var result = areEqual(real, JSON.parse(expression));
-	return result;
+	if (!result) {
+		throw('actual response body is\n' + JSON.stringify(real, null, 2));
+	}
+	return true;
 };
 
 Apickli.prototype.assertResponseBodyContainsExpression = function(expression) {


### PR DESCRIPTION
A frequent use case when testing a REST API is having a request path containing variable values, like a resource ID. This PR adds the possibility to include scenario variables and/or global variables in request paths. The variable names must be enclosed in backticks. By example:

   ```/users/`userId`/files/`fileId` ```

You can mix global and scenario variables in the same path. Scenario variable will shadow global variable with the same name.