### PR TITLE
added given syntax to pass query parameters as a data table

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ GIVEN:
 	I pipe contents of file (.*) to body
 	I have basic authentication credentials (.*) and (.*)
 	I set bearer token
+	I set query parameters to (data table with headers |parameter|value|)
 	
 WHEN:
 	I GET $resource

--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -119,3 +119,12 @@ Feature:
 
 	Scenario: checking values of scenario variables
 		Then value of scenario variable title should be undefined
+
+	Scenario: checking values of query parameter
+		Given I set query parameters to 
+		|parameter|value|
+		|argument1|1|
+		|argument2|test|
+		When I GET /get
+		Then response body path $.args.argument1 should be 1
+		And response body path $.args.argument2 should be test

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -23,6 +23,11 @@ module.exports = function() {
 		});
 	});
 
+	this.Given(/^I set query parameters to$/, function(queryParameters, callback) {
+		this.apickli.setQueryParameters(queryParameters.hashes());
+		callback();
+	});
+
 	this.Given(/^I have basic authentication credentials (.*) and (.*)$/, function(username, password, callback) {
 		this.apickli.addHttpBasicAuthorizationHeader(username, password);
 		callback();

--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -18,6 +18,7 @@ function Apickli(scheme, domain) {
 	this.httpResponse = {};
 	this.requestBody = '';
 	this.scenarioVariables = {};
+	this.queryParameters = [];
 }
 
 Apickli.prototype.addRequestHeader = function(name, value) {
@@ -30,6 +31,10 @@ Apickli.prototype.getResponseObject = function() {
 
 Apickli.prototype.setRequestBody = function(body) {
 	this.requestBody = body;
+};
+
+Apickli.prototype.setQueryParameters = function(queryParameters) {
+	this.queryParameters = queryParameters;
 };
 
 Apickli.prototype.pipeFileContentsToRequestBody = function(file, callback) {
@@ -46,8 +51,17 @@ Apickli.prototype.pipeFileContentsToRequestBody = function(file, callback) {
 
 Apickli.prototype.get = function(resource, callback) { // callback(error, response)
 	var self = this;
+	var urlQueryParameters = "";
+
+	var keys = Object.keys( this.queryParameters );
+	if (keys.length > 0) {
+		urlQueryParameters = "?" + this.queryParameters[0].parameter + "=" + this.queryParameters[0].value;
+		for( var i = 1,length = keys.length; i < length; i++ ) {
+			urlQueryParameters = urlQueryParameters + "&" + this.queryParameters[ i ].parameter + "=" + this.queryParameters[ i ].value;
+		}
+	}
 	request.get({
-		url: this.domain + resource,
+		url: this.domain + resource + urlQueryParameters,
 		headers: this.headers
 	},
 	function(error, response) {


### PR DESCRIPTION
I found that adding query parameters in the URL was a bit cumbersome when writing tests for a GET request, so this change allows you to set them in a data table as a Given clause - eg
 
Given I set query parameters to 
|parameter|value|
|argument1|1|
|argument2|test|
When I GET /get