### PR TITLE
Allow a fixturesDirectory to be defined to prefix the file passed into pipeFileContentsToRequestBody.

### DIFF
--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -23,7 +23,7 @@ Feature:
 		Then response body should contain hello-world
 
 	Scenario: Setting body payload from file
-		Given I pipe contents of file ./test/features/fixtures/requestbody.xml to body
+		Given I pipe contents of file requestbody.xml to body
 		When I POST to /post
 		Then response body should contain "data": "<a>b</a>"
 

--- a/example-project/test/features/step_definitions/httpbin.js
+++ b/example-project/test/features/step_definitions/httpbin.js
@@ -6,7 +6,7 @@ var apickli = require('apickli');
 module.exports = function() {
 	// cleanup before every scenario
 	this.Before(function(scenario, callback) {
-		this.apickli = new apickli.Apickli('http', 'httpbin.org');
+		this.apickli = new apickli.Apickli('http', 'httpbin.org', './test/features/fixtures/');
 		callback();
 	});
 

--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -12,12 +12,13 @@ var globalVariables = {};
 
 var ATTRIBUTE = 2;
 
-function Apickli(scheme, domain) {
+function Apickli(scheme, domain, fixturesDirectory) {
 	this.domain = scheme + '://' + domain;
 	this.headers = {};
 	this.httpResponse = {};
 	this.requestBody = '';
 	this.scenarioVariables = {};
+	this.fixturesDirectory = (fixturesDirectory ? fixturesDirectory : "");
 }
 
 Apickli.prototype.addRequestHeader = function(name, value) {
@@ -34,7 +35,7 @@ Apickli.prototype.setRequestBody = function(body) {
 
 Apickli.prototype.pipeFileContentsToRequestBody = function(file, callback) {
 	var self = this;
-	fs.readFile(file, 'utf8', function(err, data) {
+	fs.readFile(this.fixturesDirectory + file, 'utf8', function(err, data) {
 		if (err) {
 			callback(err);
 		}


### PR DESCRIPTION
Allow a fixturesDirectory to be defined to prefix the file passed into pipeFileContentsToRequestBody.