### PR TITLE
returning assertion result from apickli functions and verbose output from gherkin methods

### DIFF
--- a/example-project/test/features/httpbin.feature
+++ b/example-project/test/features/httpbin.feature
@@ -1,3 +1,4 @@
+@core
 Feature:
 	Httpbin.org exposes various resources for HTTP request testing
 	As Httpbin client I want to verify that all API resources are working as they should

--- a/source/Gulpfile.js
+++ b/source/Gulpfile.js
@@ -5,6 +5,18 @@ var jshint = require('gulp-jshint');
 gulp.task('test', function() {
 	var options = {
 		'steps': 'test/features/step_definitions/*.js',
+        'tags': '@core',
+		'format': 'pretty'
+	};
+
+    return gulp.src('test/features/*')
+			.pipe(cucumber(options));
+});
+
+gulp.task('console-test', function() {
+	var options = {
+		'steps': 'test/features/step_definitions/*.js',
+        'tags': '@console',
 		'format': 'pretty'
 	};
 

--- a/source/package.json
+++ b/source/package.json
@@ -25,7 +25,8 @@
     "request": "^2.55.0",
     "xmldom": "^0.1.19",
     "xpath.js": "^1.0.6",
-    "is-my-json-valid": "^2.12.3"
+    "is-my-json-valid": "^2.12.3",
+    "prettyjson": "^1.1.3"
   },
   "devDependencies": {
     "gulp": "^3.8.11",

--- a/source/test/features/console-output.feature
+++ b/source/test/features/console-output.feature
@@ -1,0 +1,63 @@
+@console
+Feature:
+	Httpbin.org exposes various resources for HTTP request testing
+	As Httpbin client I want to verify that all API resources are working as they should
+
+	Scenario: Test output - response code should be (.*)
+		Given I set User-Agent header to apickli
+		When I GET /get
+		Then response code should be 400
+        
+    Scenario: Test output - response code should be (.*)
+		Given I set User-Agent header to apickli
+		When I GET /xml
+		Then response code should be 400
+        
+    Scenario: Test output - response header (.*) should exist
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response header boo should exist
+    
+    Scenario: Test output - response header (.*) should not exist
+        When I GET /get
+        Then response header Content-Length should not exist
+        
+    Scenario: Test output - response header (.*) should be (.*)
+        When I GET /get
+        Then response header Content-Type should be foo
+        
+    Scenario: Test output - response header (.*) should not be (.*)
+        When I GET /get
+        Then response header Content-Type should not be application/json
+        
+    Scenario: Test output - response body path (.*) should be (.*)
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response body path $.headers.User-Agent should be foo
+            
+    Scenario: Test output - response header (.*) should not be (.*)
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response body path $.headers.User-Agent should not be apickli
+        
+    Scenario: Test output - response body should contain (.*)
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response body should contain foo
+        
+    Scenario: Test output - response body should not contain (.*)
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response body should not contain apickli
+    
+    Scenario: Test output - response body should be valid (xml|json)
+        When I GET /get
+        Then response body should be valid xml
+        
+    Scenario: Test output - response body should be valid (xml|json)
+        When I GET /xml
+        Then response body should be valid json
+        
+    Scenario: should successfully validate json using schema
+        When I GET /headers
+        Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema 

--- a/source/test/features/step_definitions/apickli-test.js
+++ b/source/test/features/step_definitions/apickli-test.js
@@ -8,7 +8,7 @@ var subtractionResult;
 
 module.exports = function() {
 	// cleanup before every scenario
-	this.Before(function(callback) {
+	this.Before(function(scenario, callback) {
 		this.apickli = new apickli.Apickli('http', 'httpbin.org');
 		callback();
 	});


### PR DESCRIPTION
/cc @seanapigee @sauliuz 

Console output looks like this - only for failed tests:
```
Scenario: Test output - response header (.*) should be (.*)   
    When I GET /get                                             
    Then response header Content-Type should be foo
      stepContext:
        scenario: Test output - response header (.*) should be (.*)
        step:     response header Content-Type should be foo
      testOutput:
        success:  false
        expected: foo
        actual:   application/json
        response:
          statusCode: 200
          headers:
            server:                           nginx
            date:                             Fri, 22 Jan 2016 21:16:13 GMT
            content-type:                     application/json
            content-length:                   127
            connection:                       close
            access-control-allow-origin:      *
            access-control-allow-credentials: true
          body:
            """
              {
                "args": {},
                "headers": {
                  "Host": "httpbin.org"
                },
                "origin": "82.8.64.79",
                "url": "http://httpbin.org/get"
              }

            """
```