### PR TITLE
add: removeRequestHeader and setRequestHeader methods

### DIFF
--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -50,6 +50,15 @@ Apickli.prototype.addRequestHeader = function(name, value) {
     this.headers[name] = valuesArray.join(',');
 };
 
+Apickli.prototype.removeRequestHeader = function(name) {
+    delete this.headers[name];
+};
+
+Apickli.prototype.setRequestHeader = function(name, value) {
+    this.removeRequestHeader(name);
+    this.addRequestHeader(name, value);
+};
+
 Apickli.prototype.getResponseObject = function() {
     return this.httpResponse;
 };


### PR DESCRIPTION
addRequestHeader(name, value) is always joining the value if the header already existed. These two new methods allow to remove a request header or replace it with a new value