### PR TITLE
Fixed Tests and Updated to work with Cucumber 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,6 @@ _Thank you for considering contributing to apickli._
 
 * Before submitting, please read the guide below to know more about coding conventions and benchmarks.
 
-#### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
-
-Changes that are cosmetic in nature and do not add anything substantial to the stability,
- functionality, or testability of Rails will generally not be accepted (read more about [our rationales behind this decision](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
-
 ### **Code Conventions**
 In lieu of a formal style guide, take care to maintain the existing coding style.
  Add unit tests for any new or changed functionality. Lint and test your code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+#Contributing to Apickli
+
+_Thank you for considering contributing to apickli._
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/apickli/apickli/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/apickli/apickli/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+* Before submitting, please read the guide below to know more about coding conventions and benchmarks.
+
+#### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
+
+Changes that are cosmetic in nature and do not add anything substantial to the stability,
+ functionality, or testability of Rails will generally not be accepted (read more about [our rationales behind this decision](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
+
+### **Code Conventions**
+In lieu of a formal style guide, take care to maintain the existing coding style.
+ Add unit tests for any new or changed functionality. Lint and test your code.
+
+To test the code run `gulp test`
+
+To test that the console outputs correctly run `gulp console-test`.
+ Some of these tests should fail, that is expected behavior.
+ The failed tests are designed to show how the console will output failed tests.
+
+To lint your code run `gulp jshint`
+
+#
+Thank you for your contribution!

--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -5,16 +5,14 @@ var prettyJson = require('prettyjson');
 
 var stepContext = {};
 
-module.exports = function () {    
-    this.registerHandler('BeforeScenario', function (event, callback) {
-        var scenario = event.getPayloadItem('scenario');
-        stepContext.scenario = scenario.getName();
+module.exports = function () {
+    this.registerHandler('BeforeScenario', function (scenario, callback) {
+        stepContext.scenario = scenario.getName;
         callback();
     });
 
-    this.registerHandler('BeforeStep', function(event, callback) {
-        var step = event.getPayloadItem('step');
-        stepContext.step = step.getName();
+    this.registerHandler('BeforeStep', function(step, callback) {
+        stepContext.step = step.getName;
         callback();
     });
 

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apickli",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Collection of utility functions and a gherkin framework for REST API integration testing based on cucumber.js",
   "main": "apickli.js",
   "readme": "README.md",

--- a/source/test/features/console-output.feature
+++ b/source/test/features/console-output.feature
@@ -1,73 +1,73 @@
 @console
 Feature:
-	Httpbin.org exposes various resources for HTTP request testing
-	As Httpbin client I want to verify that all API resources are working as they should
+    Httpbin.org exposes various resources for HTTP request testing
+    As Httpbin client I want to verify that all API resources are working as they should
 
-	Scenario: Test output - response code should be (.*)
-		Given I set User-Agent header to apickli
-		When I GET /get
-		Then response code should be 200
-        
     Scenario: Test output - response code should be (.*)
-		Given I set User-Agent header to apickli
-		When I GET /xml
-		Then response code should be 200
-        
+        Given I set User-Agent header to apickli
+        When I GET /get
+        Then response code should be 400
+
+    Scenario: Test output - response code should be (.*)
+        Given I set User-Agent header to apickli
+        When I GET /xml
+        Then response code should be 400
+
     Scenario: Test output - response header (.*) should exist
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response header Content-Type should exist
-    
+        Then response header boo should exist
+
     Scenario: Test output - response header (.*) should not exist
         When I GET /get
-        Then response header User-Agent should not exist
-        
+        Then response header Content-Length should not exist
+
     Scenario: Test output - response header (.*) should be (.*)
         When I GET /get
-        Then response header Content-Type should be application/json
-        
+        Then response header Content-Type should be foo
+
     Scenario: Test output - response header (.*) should not be (.*)
         When I GET /get
-        Then response header Content-Type should not be application/xml
-        
+        Then response header Content-Type should not be application/json
+
     Scenario: Test output - response body path (.*) should be (.*)
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response body path $.url should be http://httpbin.org/get
-            
+        Then response body path $.headers.User-Agent should be foo
+
     Scenario: Test output - response header (.*) should not be (.*)
-        Given I set User-Agent header to cucumber
+        Given I set User-Agent header to apickli
         When I GET /get
         Then response body path $.headers.User-Agent should not be apickli
-        
+
     Scenario: Test output - response body should contain (.*)
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response body should contain url
-        
+        Then response body should contain foo
+
     Scenario: Test output - response body should not contain (.*)
         Given I set User-Agent header to apickli
         When I GET /get
         Then response body should not contain apickli
-    
+
+    Scenario: Test output - response body should be valid (xml|json)
+        When I GET /get
+        Then response body should be valid xml
+
     Scenario: Test output - response body should be valid (xml|json)
         When I GET /xml
-        Then response body should be valid xml
-        
-    Scenario: Test output - response body should be valid (xml|json)
-        When I GET /get
         Then response body should be valid json
-        
+
     Scenario: should successfully validate json using schema
-        When I GET /get
-        Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema 
+        When I GET /headers
+        Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema
 
     Scenario: should successfully validate json array
         Given I set body to ["a","b","c"]
         When I POST to /post
-        And response body path $.json should be of type array
+        And response body path $.headers.Host should be of type array
 
     Scenario: should successfully validate json array length
         Given I set body to ["a","b","c"]
         When I POST to /post
-        And response body path $.json should be of type array with length 3
+        And response body path $.json should be of type array with length 2

--- a/source/test/features/console-output.feature
+++ b/source/test/features/console-output.feature
@@ -6,44 +6,44 @@ Feature:
 	Scenario: Test output - response code should be (.*)
 		Given I set User-Agent header to apickli
 		When I GET /get
-		Then response code should be 400
+		Then response code should be 200
         
     Scenario: Test output - response code should be (.*)
 		Given I set User-Agent header to apickli
 		When I GET /xml
-		Then response code should be 400
+		Then response code should be 200
         
     Scenario: Test output - response header (.*) should exist
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response header boo should exist
+        Then response header Content-Type should exist
     
     Scenario: Test output - response header (.*) should not exist
         When I GET /get
-        Then response header Content-Length should not exist
+        Then response header User-Agent should not exist
         
     Scenario: Test output - response header (.*) should be (.*)
         When I GET /get
-        Then response header Content-Type should be foo
+        Then response header Content-Type should be application/json
         
     Scenario: Test output - response header (.*) should not be (.*)
         When I GET /get
-        Then response header Content-Type should not be application/json
+        Then response header Content-Type should not be application/xml
         
     Scenario: Test output - response body path (.*) should be (.*)
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response body path $.headers.User-Agent should be foo
+        Then response body path $.url should be http://httpbin.org/get
             
     Scenario: Test output - response header (.*) should not be (.*)
-        Given I set User-Agent header to apickli
+        Given I set User-Agent header to cucumber
         When I GET /get
         Then response body path $.headers.User-Agent should not be apickli
         
     Scenario: Test output - response body should contain (.*)
         Given I set User-Agent header to apickli
         When I GET /get
-        Then response body should contain foo
+        Then response body should contain url
         
     Scenario: Test output - response body should not contain (.*)
         Given I set User-Agent header to apickli
@@ -51,23 +51,23 @@ Feature:
         Then response body should not contain apickli
     
     Scenario: Test output - response body should be valid (xml|json)
-        When I GET /get
+        When I GET /xml
         Then response body should be valid xml
         
     Scenario: Test output - response body should be valid (xml|json)
-        When I GET /xml
+        When I GET /get
         Then response body should be valid json
         
     Scenario: should successfully validate json using schema
-        When I GET /headers
+        When I GET /get
         Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema 
 
     Scenario: should successfully validate json array
         Given I set body to ["a","b","c"]
         When I POST to /post
-        And response body path $.headers.Host should be of type array
+        And response body path $.json should be of type array
 
     Scenario: should successfully validate json array length
         Given I set body to ["a","b","c"]
         When I POST to /post
-        And response body path $.json should be of type array with length 2
+        And response body path $.json should be of type array with length 3

--- a/source/test/features/fixtures/requestBody.xml
+++ b/source/test/features/fixtures/requestBody.xml
@@ -1,1 +1,1 @@
-../../../../example-project/test/features/fixtures/requestBody.xml
+<a>b</a>

--- a/source/test/features/httpbin.feature
+++ b/source/test/features/httpbin.feature
@@ -1,259 +1,259 @@
 @core
 Feature:
-    Httpbin.org exposes various resources for HTTP request testing
-    As Httpbin client I want to verify that all API resources are working as they should
+  Httpbin.org exposes various resources for HTTP request testing
+  As Httpbin client I want to verify that all API resources are working as they should
 
-    Scenario: Setting headers in GET request
-        Given I set User-Agent header to apickli
-        When I GET /get
-        Then response body path $.headers.User-Agent should be apickli
+  Scenario: Setting headers in GET request
+    Given I set User-Agent header to apickli
+    When I GET /get
+    Then response body path $.headers.User-Agent should be apickli
 
-    Scenario: checking values of headers passed as datatable in get request
-        Given I set headers to
-            |name|value|
-            |User-Agent|apickli|
-            |Accept|application/json|
-        When I GET /get
-        Then response body path $.headers.Accept should be application/json
-        And response body path $.headers.User-Agent should be apickli
+  Scenario: checking values of headers passed as datatable in get request
+    Given I set headers to
+      | name          | value            |
+      | Accept        | application/json |
+      | User-Agent    | apickli          |
+    When I GET /get
+    Then response body path $.headers.Accept should be application/json
+    And response body path $.headers.User-Agent should be apickli
 
-    Scenario: combine headers passed as table and Given syntax
-        Given I set Custom-Header header to abcd
-        And I set headers to
-            |name|value|
-            |User-Agent|apickli|
-            |Accept|application/json|
-        When I GET /get
-        Then response body path $.headers.Accept should be application/json
-        And response body path $.headers.User-Agent should be apickli
-        And response body path $.headers.Custom-Header should be abcd
+  Scenario: combine headers passed as table and Given syntax
+    Given I set Custom-Header header to abcd
+    And I set headers to
+      | name       | value            |
+      | User-Agent | apickli          |
+      | Accept     | application/json |
+    When I GET /get
+    Then response body path $.headers.Accept should be application/json
+    And response body path $.headers.User-Agent should be apickli
+    And response body path $.headers.Custom-Header should be abcd
 
-    Scenario: Same header field with multiple values
-        Given I set Custom-Header header to A
-        And I set Custom-Header header to B
-        And I set headers to
-            |name|value|
-            |Custom-Header|C|
-            |Custom-Header|D|
-        When I GET /get
-        Then response body path $.headers.Custom-Header should be A,B,C,D
+  Scenario: Same header field with multiple values
+    Given I set Custom-Header header to A
+    And I set Custom-Header header to B
+    And I set headers to
+      | name          | value |
+      | Custom-Header | C     |
+      | Custom-Header | D     |
+    When I GET /get
+    Then response body path $.headers.Custom-Header should be A,B,C,D
 
-    Scenario: Setting body payload in POST request
-        Given I set body to {"key":"hello-world"}
-        When I POST to /post
-        Then response body should contain hello-world
+  Scenario: Setting body payload in POST request
+    Given I set body to {"key":"hello-world"}
+    When I POST to /post
+    Then response body should contain hello-world
 
-    Scenario: Setting body payload in PUT request
-        Given I set body to {"key":"hello-world"}
-        When I PUT /put
-        Then response body should contain hello-world
+  Scenario: Setting body payload in PUT request
+    Given I set body to {"key":"hello-world"}
+    When I PUT /put
+    Then response body should contain hello-world
 
-    Scenario: Setting body payload in DELETE request
-        Given I set body to {"key":"hello-world"}
-        When I DELETE /delete
-        Then response body should contain hello-world
+  Scenario: Setting body payload in DELETE request
+    Given I set body to {"key":"hello-world"}
+    When I DELETE /delete
+    Then response body should contain hello-world
 
-    Scenario: Setting body payload from file
-        Given I pipe contents of file ./test/features/fixtures/requestbody.xml to body
-        When I POST to /post
-        Then response body should contain "<a>b</a>"
+  Scenario: Setting body payload from file
+    Given I pipe contents of file ./test/features/fixtures/requestbody.xml to body
+    When I POST to /post
+    Then response body should contain "<a>b</a>"
 
-    Scenario: Sending request with basic auth authentication
-        Given I have basic authentication credentials username and password
-        When I POST to /post
-        Then response body path $.headers.Authorization should be Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+  Scenario: Sending request with basic auth authentication
+    Given I have basic authentication credentials username and password
+    When I POST to /post
+    Then response body path $.headers.Authorization should be Basic dXNlcm5hbWU6cGFzc3dvcmQ=
 
-    Scenario: Parsing response xml body
-        When I GET /xml
-        Then response body path /slideshow/slide[1]/title should be Wake up to WonderWidgets!
+  Scenario: Parsing response xml body
+    When I GET /xml
+    Then response body path /slideshow/slide[1]/title should be Wake up to WonderWidgets!
 
-    Scenario: Response body content type assertions (xml)
-        When I GET /xml
-        Then response body should be valid xml
+  Scenario: Response body content type assertions (xml)
+    When I GET /xml
+    Then response body should be valid xml
 
-    Scenario: Response body content type assertions (json)
-        When I GET /get
-        Then response body should be valid json
+  Scenario: Response body content type assertions (json)
+    When I GET /get
+    Then response body should be valid json
 
-    Scenario: Checking headers in response
-        When I GET /xml
-        Then response header server should exist
-        And response header boo should not exist
+  Scenario: Checking headers in response
+    When I GET /xml
+    Then response header server should exist
+    And response header boo should not exist
 
-    Scenario: Response code checks
-        When I GET /xml
-        Then response code should be 200
-        And response code should not be 404
+  Scenario: Response code checks
+    When I GET /xml
+    Then response code should be 200
+    And response code should not be 404
 
-    Scenario: Response header value assertions
-        When I GET /xml
-        Then response header Content-Type should be application/xml
-        And response header Content-Type should be [a-z]/xml
-        And response header Connection should not be boo
+  Scenario: Response header value assertions
+    When I GET /xml
+    Then response header Content-Type should be application/xml
+    And response header Content-Type should be [a-z]/xml
+    And response header Connection should not be boo
 
-    Scenario: Response body text assertions
-        When I GET /xml
-        Then response body should contain WonderWidgets
-        And response body should contain Wonder[Wdgist]
-        And response body should not contain boo
+  Scenario: Response body text assertions
+    When I GET /xml
+    Then response body should contain WonderWidgets
+    And response body should contain Wonder[Wdgist]
+    And response body should not contain boo
 
-    Scenario: Response body xpath assertions
-        When I GET /xml
-        Then response body path /slideshow/slide[2]/title should be [a-z]+
-        And response body path /slideshow/slide[2]/title should not be \d+
+  Scenario: Response body xpath assertions
+    When I GET /xml
+    Then response body path /slideshow/slide[2]/title should be [a-z]+
+    And response body path /slideshow/slide[2]/title should not be \d+
 
-    Scenario: Response body jsonpath assertions
-        Given I set User-Agent header to apickli
-        When I GET /get
-        Then response body path $.headers.User-Agent should be [a-z]+
-        And response body path $.headers.User-Agent should not be \d+
+  Scenario: Response body jsonpath assertions
+    Given I set User-Agent header to apickli
+    When I GET /get
+    Then response body path $.headers.User-Agent should be [a-z]+
+    And response body path $.headers.User-Agent should not be \d+
 
-    Scenario: Access token retrieval from response body (authorization code grant, password, client credentials)
-        Given I set Token header to token123
-        When I GET /get
-        Then I store the value of body path $.headers.Token as access token
+  Scenario: Access token retrieval from response body (authorization code grant, password, client credentials)
+    Given I set Token header to token123
+    When I GET /get
+    Then I store the value of body path $.headers.Token as access token
 
-    Scenario: Using access token
-        Given I set bearer token
-        When I GET /get
-        Then response body path $.headers.Authorization should be Bearer token123
+  Scenario: Using access token
+    Given I set bearer token
+    When I GET /get
+    Then response body path $.headers.Authorization should be Bearer token123
 
-    Scenario: Quota testing - first request
-        Given I set X-Quota-Remaining header to 10
-        When I GET /get
-        Then I store the value of body path $.headers.X-Quota-Remaining as remaining1 in global scope
+  Scenario: Quota testing - first request
+    Given I set X-Quota-Remaining header to 10
+    When I GET /get
+    Then I store the value of body path $.headers.X-Quota-Remaining as remaining1 in global scope
 
-    Scenario: Quota testing - second request
-        Given I set X-Quota-Remaining header to 9
-        When I GET /get
-        Then I store the value of body path $.headers.X-Quota-Remaining as remaining2 in global scope
+  Scenario: Quota testing - second request
+    Given I set X-Quota-Remaining header to 9
+    When I GET /get
+    Then I store the value of body path $.headers.X-Quota-Remaining as remaining2 in global scope
 
-    Scenario: Quota testing - assertion
-        When I subtract remaining2 from remaining1
-        Then result should be 1
+  Scenario: Quota testing - assertion
+    When I subtract remaining2 from remaining1
+    Then result should be 1
 
-    Scenario: setting header value as variable
-        When I GET /get
-        Then I store the value of response header Server as agent in scenario scope
-        And value of scenario variable agent should be nginx
+  Scenario: setting header value as variable
+    When I GET /get
+    Then I store the value of response header Server as agent in scenario scope
+    And value of scenario variable agent should be nginx
 
-    Scenario: setting body path as variable (xml)
-        When I GET /xml
-        And I store the value of body path /slideshow/slide[2]/title as title in scenario scope
-        Then value of scenario variable title should be Overview
+  Scenario: setting body path as variable (xml)
+    When I GET /xml
+    And I store the value of body path /slideshow/slide[2]/title as title in scenario scope
+    Then value of scenario variable title should be Overview
 
-    Scenario: setting body path as variable (json)
-        Given I set User-Agent header to apickli
-        When I GET /get
-        And I store the value of body path $.headers.User-Agent as agent in scenario scope
-        Then value of scenario variable agent should be apickli
+  Scenario: setting body path as variable (json)
+    Given I set User-Agent header to apickli
+    When I GET /get
+    And I store the value of body path $.headers.User-Agent as agent in scenario scope
+    Then value of scenario variable agent should be apickli
 
-    Scenario: checking values of scenario variables
-        Then value of scenario variable title should be undefined
+  Scenario: checking values of scenario variables
+    Then value of scenario variable title should be undefined
 
-    Scenario: checking values of query parameters passed in url in get request
-        When I GET /get?argument1=1&argument2=test
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameters passed in url in get request
+    When I GET /get?argument1=1&argument2=test
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameter passed as datatable in get request
-        Given I set query parameters to
-            |parameter|value|
-            |argument1|1|
-            |argument2|test|
-        When I GET /get
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameter passed as datatable in get request
+    Given I set query parameters to
+      | parameter | value |
+      | argument1 | 1     |
+      | argument2 | test  |
+    When I GET /get
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameters passed in url in post request
-        When I POST to /post?argument1=1&argument2=test
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameters passed in url in post request
+    When I POST to /post?argument1=1&argument2=test
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameter passed as datatable in post request
-        Given I set query parameters to
-            |parameter|value|
-            |argument1|1|
-            |argument2|test|
-        When I POST to /post
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameter passed as datatable in post request
+    Given I set query parameters to
+      | parameter | value |
+      | argument1 | 1     |
+      | argument2 | test  |
+    When I POST to /post
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameters passed in url in put request
-        When I PUT /put?argument1=1&argument2=test
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameters passed in url in put request
+    When I PUT /put?argument1=1&argument2=test
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameter passed as datatable in put request
-        Given I set query parameters to
-            |parameter|value|
-            |argument1|1|
-            |argument2|test|
-        When I PUT /put
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameter passed as datatable in put request
+    Given I set query parameters to
+      | parameter | value |
+      | argument1 | 1     |
+      | argument2 | test  |
+    When I PUT /put
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameters passed in url in delete request
-        When I DELETE /delete?argument1=1&argument2=test
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameters passed in url in delete request
+    When I DELETE /delete?argument1=1&argument2=test
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameter passed as datatable in delete request
-        Given I set query parameters to
-            |parameter|value|
-            |argument1|1|
-            |argument2|test|
-        When I DELETE /delete
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameter passed as datatable in delete request
+    Given I set query parameters to
+      | parameter | value |
+      | argument1 | 1     |
+      | argument2 | test  |
+    When I DELETE /delete
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameters passed in url in patch request
-        When I PATCH /patch?argument1=1&argument2=test
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameters passed in url in patch request
+    When I PATCH /patch?argument1=1&argument2=test
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: checking values of query parameter passed as datatable in patch request
-        Given I set query parameters to
-            |parameter|value|
-            |argument1|1|
-            |argument2|test|
-        When I PATCH /patch
-        Then response body path $.args.argument1 should be 1
-        And response body path $.args.argument2 should be test
+  Scenario: checking values of query parameter passed as datatable in patch request
+    Given I set query parameters to
+      | parameter | value |
+      | argument1 | 1     |
+      | argument2 | test  |
+    When I PATCH /patch
+    Then response body path $.args.argument1 should be 1
+    And response body path $.args.argument2 should be test
 
-    Scenario: should successfully send an OPTIONS call to target API and assert response
-        When I request OPTIONS for /get
-        Then response code should be 200
-        And response header Access-Control-Allow-Credentials should be true
-        And response header Access-Control-Allow-Methods should be GET, POST, PUT, DELETE, PATCH, OPTIONS
-        And response header Allow should be HEAD, OPTIONS, GET
-        And response header Content-Length should be 0
+  Scenario: should successfully send an OPTIONS call to target API and assert response
+    When I request OPTIONS for /get
+    Then response code should be 200
+    And response header Access-Control-Allow-Credentials should be true
+    And response header Access-Control-Allow-Methods should be GET, POST, PUT, DELETE, PATCH, OPTIONS
+    And response header Allow should be HEAD, OPTIONS, GET
+    And response header Content-Length should be 0
 
-    Scenario: should differentiate between empty string and non-existing element in JSON path assertions
-        When I GET /get
-        Then response code should be 200
-        And response body path $.origin should be [0-9\.]+
-        And response body path $.notthere should be undefined
+  Scenario: should differentiate between empty string and non-existing element in JSON path assertions
+    When I GET /get
+    Then response code should be 200
+    And response body path $.origin should be [0-9\.]+
+    And response body path $.notthere should be undefined
 
-    Scenario: should successfully validate json using schema
-        When I GET /get
-        Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema
+  Scenario: should successfully validate json using schema
+    When I GET /get
+    Then response body should be valid according to schema file ./test/features/fixtures/get-simple.schema
 
-    Scenario: should successfully validate json array
-        Given I set body to ["a","b","c"]
-        When I POST to /post
-        Then response body path $.json should be of type array
-        And response body path $.json should be of type array with length 3
+  Scenario: should successfully validate json array
+    Given I set body to ["a","b","c"]
+    When I POST to /post
+    Then response body path $.json should be of type array
+    And response body path $.json should be of type array with length 3
 
-    Scenario: should successfully validate json object array
-        Given I set body to [{"a":1},{"b":2},{"c":3}]
-        When I POST to /post
-        Then response body path $.json should be of type array
-        And response body path $.json should be of type array with length 3
+  Scenario: should successfully validate json object array
+    Given I set body to [{"a":1},{"b":2},{"c":3}]
+    When I POST to /post
+    Then response body path $.json should be of type array
+    And response body path $.json should be of type array with length 3
 
-    Scenario: should successfully pipe form parameters
-        Given I set Authorization header to Basic abcd
-        And I pipe contents of file ./test/features/fixtures/formparams to body
-        When I POST to /post
-        Then response code should be 200
-        And response body path $.data should be a=a&b=b&c=c
+  Scenario: should successfully pipe form parameters
+    Given I set Authorization header to Basic abcd
+    And I pipe contents of file ./test/features/fixtures/formparams to body
+    When I POST to /post
+    Then response code should be 200
+    And response body path $.data should be a=a&b=b&c=c

--- a/source/test/features/injecting-variables.feature
+++ b/source/test/features/injecting-variables.feature
@@ -45,7 +45,7 @@ Feature:
 		Then response body should contain hello-world
 
 	Scenario: Setting body payload from file using variable
-        Given I store the raw value ./test/features/fixtures/requestbody.xml as myFilePath in scenario scope
+        Given I store the raw value ./test/features/fixtures/requestBody.xml as myFilePath in scenario scope
 		And I pipe contents of file `myFilePath` to body
 		When I POST to /post
 		Then response body should contain "<a>b</a>"

--- a/source/test/features/step_definitions/apickli-gherkin.js
+++ b/source/test/features/step_definitions/apickli-gherkin.js
@@ -1,1 +1,5 @@
-../../../apickli/apickli-gherkin.js
+/* jslint node: true */
+'use strict';
+
+
+module.exports = require('../../../apickli/apickli-gherkin')

--- a/source/test/features/step_definitions/apickli-gherkin.js
+++ b/source/test/features/step_definitions/apickli-gherkin.js
@@ -2,4 +2,4 @@
 'use strict';
 
 
-module.exports = require('../../../apickli/apickli-gherkin')
+module.exports = require('../../../apickli/apickli-gherkin');

--- a/source/test/features/step_definitions/apickli-test.js
+++ b/source/test/features/step_definitions/apickli-test.js
@@ -10,6 +10,7 @@ module.exports = function() {
 	// cleanup before every scenario
 	this.Before(function(scenario, callback) {
 		this.apickli = new apickli.Apickli('http', 'httpbin.org');
+		this.apickli.addRequestHeader('Cache-Control','no-cache');
 		callback();
 	});
     


### PR DESCRIPTION
Fixed all the tests so that they pass. Changed the apickli-gherkin file in step_definitions to a require statement instead of a symlink. Changed the registerHandler methods to support cucumber.js 2.0 which no longer passes an event with a getPayloadItem method.