### PR TITLE
Apickli requires higher version of Cucumber - use 0.8.1 to start with

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "JSONPath": "^0.11.0",
+    "cucumber": "^0.8.1",
     "is-my-json-valid": "^2.12.3",
     "path": "^0.12.7",
     "prettyjson": "^1.1.3",


### PR DESCRIPTION
Testable with
$ `node_modules/cucumber/bin/cucumber.js test/features/httpbin.feature`
(currently shows one minor error due to slightly differently ordered response from httpbin)