### PR TITLE
Gulp Testing + Bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
 before_script:
   - cd source && npm install && cd ..
   - npm install -g cucumber@^1.0.0
+  - npm install -g gulp
   - cp source/apickli/apickli-gherkin.js source/test/features/step_definitions/
 script:
-  - cd source && cucumber-js test/ --tags @core
+  - cd source && cucumber-js test/ --tags @core && gulp test
   

--- a/source/package.json
+++ b/source/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "gulp": "^3.8.11",
-    "gulp-cucumber": "0.0.9",
+    "gulp-cucumber": "0.0.22",
     "gulp-jshint": "^1.10.0",
     "jshint-stylish": "^1.0.2"
   }

--- a/source/test/features/httpbin.feature
+++ b/source/test/features/httpbin.feature
@@ -231,7 +231,9 @@ Feature:
     Then response code should be 200
     And response header Access-Control-Allow-Credentials should be true
     And response header Access-Control-Allow-Methods should be GET, POST, PUT, DELETE, PATCH, OPTIONS
-    And response header Allow should be OPTIONS, GET, HEAD
+    And response header Allow should be (.*)OPTIONS(.*)
+    And response header Allow should be (.*)GET(.*)
+    And response header Allow should be (.*)HEAD(.*)
     And response header Content-Length should be 0
 
   Scenario: should differentiate between empty string and non-existing element in JSON path assertions


### PR DESCRIPTION
- Added Gulp testing to Travis CI
- Upgraded gulp-cucumber version to resolve setDefaultTimeout()
- Ensured Allow headers can be accepted in any order, as intermittently this causes failures (see https://travis-ci.org/seantdg/apickli/builds/264410697)