### PR TITLE
Fix handling errors from fs

### DIFF
--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -168,10 +168,10 @@ Apickli.prototype.pipeFileContentsToRequestBody = function(file, callback) {
     fs.readFile(path.join(this.fixturesDirectory, file), 'utf8', function(err, data) {
         if (err) {
             callback(err);
-        }
-
-        self.setRequestBody(data);
-        callback();
+        } else{
+            self.setRequestBody(data);
+           callback();
+       }
     });
 };
 
@@ -362,14 +362,15 @@ Apickli.prototype.validateResponseWithSchema = function(schemaFile, callback) {
     fs.readFile(path.join(this.fixturesDirectory, schemaFile), 'utf8', function(err, jsonSchemaString) {
         if (err) {
             callback(err);
-        }
+        } else {
 
-        const jsonSchema = JSON.parse(jsonSchemaString);
-        const responseBody = JSON.parse(self.getResponseObject().body);
+	    const jsonSchema = JSON.parse(jsonSchemaString);
+	    const responseBody = JSON.parse(self.getResponseObject().body);
 
-        const validate = jsonSchemaValidator(jsonSchema, {verbose: true});
-        const success = validate(responseBody);
-        callback(getAssertionResult(success, validate.errors, null, self));
+            const validate = jsonSchemaValidator(jsonSchema, {verbose: true});
+            const success = validate(responseBody);
+            callback(getAssertionResult(success, validate.errors, null, self));
+       }
     });
 };
 
@@ -380,20 +381,21 @@ Apickli.prototype.validateResponseWithSwaggerSpecDefinition = function(definitio
     fs.readFile(path.join(this.fixturesDirectory, swaggerSpecFile), 'utf8', function(err, swaggerSpecString) {
         if (err) {
             callback(err);
+        } else{
+
+            const swaggerObject = JSON.parse(swaggerSpecString);
+            const responseBody = JSON.parse(self.getResponseObject().body);
+
+            spec.validateModel(swaggerObject, '#/definitions/' + definitionName, responseBody, function(err, result) {
+                if (err) {
+                    callback(getAssertionResult(false, null, err, self));
+                } else if (result && result.errors) {
+                    callback(getAssertionResult(false, null, result.errors, self));
+                } else {
+                    callback(getAssertionResult(true, null, null, self));
+                }
+            });
         }
-
-        const swaggerObject = JSON.parse(swaggerSpecString);
-        const responseBody = JSON.parse(self.getResponseObject().body);
-
-        spec.validateModel(swaggerObject, '#/definitions/' + definitionName, responseBody, function(err, result) {
-            if (err) {
-                callback(getAssertionResult(false, null, err, self));
-            } else if (result && result.errors) {
-                callback(getAssertionResult(false, null, result.errors, self));
-            } else {
-                callback(getAssertionResult(true, null, null, self));
-            }
-        });
     });
 };
 


### PR DESCRIPTION
When handling errors from fs, execution continues after calling the
callback function with the error information:  For example:

```
Apickli.prototype.pipeFileContentsToRequestBody = function(file, callback) {
    const self = this;
    file = this.replaceVariables(file);
    fs.readFile(path.join(this.fixturesDirectory, file), 'utf8', function(err, data) {
        if (err) {
            callback(err);
        } 

        self.setRequestBody(data);
        callback();
    });
};

```

This causes errors like the following if the required resource (e.g.a fitxure) is not present:
```
  @core
  Scenario: Setting body payload from file
  ✖ Given I pipe contents of file ./test/features/fixtures/requestBody.xml to body
/home/pablo/workspace/apickli/source/apickli/apickli.js:417
    const startIndex = resource.indexOf(variableChar, offset);
                               ^

TypeError: Cannot read property 'indexOf' of undefined
    at Apickli.replaceVariables (/home/pablo/workspace/apickli/source/apickli/apickli.js:417:32)
    at Apickli.setRequestBody (/home/pablo/workspace/apickli/source/apickli/apickli.js:125:17)
    at ReadFileContext.callback (/home/pablo/workspace/apickli/source/apickli/apickli.js:173:14)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:366:13)

```
Signed-off-by: Pablo <pablochacin@gmail.com>