### PR TITLE
remove authorization header before setting it

### DIFF
--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -209,6 +209,7 @@ Apickli.prototype.addHttpBasicAuthorizationHeader = function(username, password)
     username = this.replaceVariables(username);
     password = this.replaceVariables(password);
     const b64EncodedValue = base64Encode(username + ':' + password);
+    this.removeRequestHeader('Authorization');
     this.addRequestHeader('Authorization', 'Basic ' + b64EncodedValue);
 };
 
@@ -308,6 +309,7 @@ Apickli.prototype.setAccessTokenFromResponseBodyPath = function(path) {
 
 Apickli.prototype.setBearerToken = function() {
     if (accessToken) {
+      this.removeRequestHeader('Authorization');
       return this.addRequestHeader('Authorization', 'Bearer ' + accessToken);
     } else {
       return false;


### PR DESCRIPTION
Currently if for some reason you have Authorization header already set, and then you call  addHttpBasicAuthorizationHeader or setBearerToken then the new details are appended to the  Authorization header rather than replacing them.

This change just clears the Authorization before setting it
