### PR TITLE
Ability to pass qsStringifyOptions or any other into apickli request

### DIFF
--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -83,6 +83,7 @@ function Apickli(scheme, domain, fixturesDirectory, variableChar) {
     this.fixturesDirectory = (fixturesDirectory ? fixturesDirectory : '');
     this.queryParameters = {};
     this.formParameters = {};
+    this.predefinedOptions = {};
     this.clientTLSConfig = {};
     this.selectedClientTLSConfig = '';
     this.variableChar = (variableChar ? variableChar : '`');
@@ -443,7 +444,7 @@ Apickli.prototype.replaceVariables = function(resource, scope, variableChar, off
 
 Apickli.prototype.sendRequest = function(method, resource, callback) {
     const self = this;
-    const options = {};
+    const options = this.predefinedOptions || {};
     options.url = this.domain + resource;
     options.method = method;
     options.headers = this.headers;


### PR DESCRIPTION
Added predefinedOptions parameter in order to pass options such as qsStringifyOptions for querystring.js using sendRequest() method. For example, as was mention in #81 for sending request with duplicate query parameters it is required to pass qsStringifyOptions= {arrayFormat: 'repeat'} into request.js -> querystring.js and using predefinedOptions.qsStringifyOptions is a simple way of providing flexibility to apickli request