### PR TITLE
rename predefinedOptions to httpRequestOptions

### DIFF
--- a/source/apickli/apickli.js
+++ b/source/apickli/apickli.js
@@ -83,7 +83,7 @@ function Apickli(scheme, domain, fixturesDirectory, variableChar) {
     this.fixturesDirectory = (fixturesDirectory ? fixturesDirectory : '');
     this.queryParameters = {};
     this.formParameters = {};
-    this.predefinedOptions = {};
+    this.httpRequestOptions = {};
     this.clientTLSConfig = {};
     this.selectedClientTLSConfig = '';
     this.variableChar = (variableChar ? variableChar : '`');
@@ -444,7 +444,7 @@ Apickli.prototype.replaceVariables = function(resource, scope, variableChar, off
 
 Apickli.prototype.sendRequest = function(method, resource, callback) {
     const self = this;
-    const options = this.predefinedOptions || {};
+    const options = this.httpRequestOptions || {};
     options.url = this.domain + resource;
     options.method = method;
     options.headers = this.headers;


### PR DESCRIPTION
Proposal to rename `predefinedOptions` to `httpRequestOptions` as I think the former doesn't communicate the purpose very well.