### PR TITLE
Add support to clear request body and options

### DIFF
--- a/source/apickli/apickli-gherkin.js
+++ b/source/apickli/apickli-gherkin.js
@@ -272,3 +272,9 @@ Then(/^value of scenario variable (.*) should be (.*)$/, function(variableName, 
     callback(new Error('value of variable ' + variableName + ' isn\'t equal to ' + variableValue));
   }
 });
+
+When(/^I clear the request$/, function(callback) {
+  this.apickli.httpRequestOptions = {};
+  this.apickli.requestBody = '';
+  callback();
+});

--- a/source/test/features/httpbin.feature
+++ b/source/test/features/httpbin.feature
@@ -58,6 +58,13 @@ Feature:
     When I DELETE /delete
     Then response body should contain hello-world
 
+  Scenario: Firing two posts in same scenario
+    Given I set body to {"key":"hello-world"}
+    When I POST to /post
+    And I clear the request
+    And I POST to /post
+    Then response body should not contain hello-world
+
   Scenario: Setting body payload from file
     Given I pipe contents of file ./test/features/fixtures/requestBody.xml to body
     When I POST to /post


### PR DESCRIPTION
This fixes the issue#162 

Problem: Request options and body is shared between requests. This can cause unwanted options being transmitted which causes undesirable behavior

Solution: The fix provides an option to clear the request body and options